### PR TITLE
iOS respects InputTransparency

### DIFF
--- a/Source/OxyPlot.Maui.Skia/PlotViewBase.Events.cs
+++ b/Source/OxyPlot.Maui.Skia/PlotViewBase.Events.cs
@@ -22,7 +22,30 @@ namespace OxyPlot.Maui.Skia
         {
             var touchEffect = new MyTouchEffect();
             touchEffect.TouchAction += TouchEffect_TouchAction;
-            this.Effects.Add(touchEffect);
+            if (!InputTransparent)
+            {
+                this.Effects.Add(touchEffect);
+            }
+            this.PropertyChanged += (_, args) =>
+            {
+                if (args.PropertyName is null) return;
+                if (args.PropertyName != nameof(InputTransparent)) return;
+                if (InputTransparent)
+                {
+                    if (this.Effects.Contains(touchEffect))
+                    {
+                        this.Effects.Remove(touchEffect);
+                    }
+                }
+                else
+                {
+                    if (!this.Effects.Contains(touchEffect))
+                    {
+                        this.Effects.Add(touchEffect);
+                    }
+                    
+                }
+            };
         }
 
         private void TouchEffect_TouchAction(object sender, TouchActionEventArgs e)


### PR DESCRIPTION
I had a scenario where there were two graphs. One was visible the other was not. The invisible one had its InputTransparent set to true but it seemed to still intercept touches.

This was my solution to the problem.

There might still exist an issue if there are two graphs on the screen next to each other and both want to intercept touches.